### PR TITLE
[GHA] Add github config for pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+name: Cypress Tests
+
+on:
+  # push:
+  branches:
+    - main
+  workflow_dispatch:
+
+jobs:
+  cypress-run:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cypress run in Chrome
+        uses: cypress-io/github-action@v6
+        with:
+          browser: chrome
+          command: npm run test:gha
+        continue-on-error: true
+
+      - name: Merge Mochawesome reports
+        run: npx mochawesome-merge cypress/results/*.json > cypress/results/merged-reports.json
+
+      - name: Generate HTML Reports
+        run: npx marge cypress/results/merged-reports.json --reportDir cypress/results -f "test-report.html"
+
+      - name: Upload HTML Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: Cypress HTML Report
+          path: cypress/results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,10 @@
 name: Cypress Tests
 
 on:
-  # push:
+  push:
   branches:
     - main
+    - github_actions_setup
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate Cypress end-to-end testing. The workflow includes steps for running tests in Chrome, merging test reports, generating HTML reports, and uploading the final report as an artifact.

### New GitHub Actions Workflow:
* `.github/workflows/main.yml`: Added a workflow named "Cypress Tests" triggered on pushes to the `main` branch and manual dispatch. It includes the following steps:
  - Sets up Node.js using `actions/setup-node@v3` with Node.js version 22.  
  - Checks out the repository using `actions/checkout@v4`.  
  - Runs Cypress tests in Chrome using `cypress-io/github-action@v6` with the `npm run test:gha` command.  
  - Merges Mochawesome JSON reports into a single file using `npx mochawesome-merge`.  
  - Generates an HTML test report using `npx marge`.  
  - Uploads the HTML report as an artifact using `actions/upload-artifact@v4`.