### PR TITLE
[CircleCI] Add circleCI config for pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,62 @@
+version: 2.1
+
+executors:
+  node-executor:
+    docker:
+      - image: cimg/node:22.1.0-browsers # Includes Node.js, Chrome, and Firefox
+    working_directory: ~/project
+
+jobs:
+  cypress-tests:
+    executor: node-executor
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - npm-cache-{{ checksum "package-lock.json" }}
+
+      - run:
+          name: Install dependencies
+          command: npm ci
+
+      - save_cache:
+          paths:
+            - ~/.npm
+          key: npm-cache-{{ checksum "package-lock.json" }}
+
+      - run:
+          name: Install Google Chrome
+          command: |
+            sudo apt update
+            sudo apt install -y wget curl gnupg unzip
+            curl -sSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor | sudo tee /usr/share/keyrings/google-linux-signing-keyring.gpg > /dev/null
+            echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-linux-signing-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
+            sudo apt update
+            sudo apt install -y google-chrome-stable
+            google-chrome --version
+
+      - run:
+          name: Run Cypress tests in Chrome
+          command: npm run test:cci
+          when: always
+
+      - run:
+          name: Merge Mochawesome reports
+          command: |
+            mkdir -p cypress/results
+            npx mochawesome-merge cypress/results/*.json > cypress/results/merged-reports.json || echo "No reports to merge."
+
+      - run:
+          name: Generate HTML report
+          command: npx mochawesome-report-generator cypress/results/merged-reports.json --reportDir cypress/results --reportFilename test-report.html
+
+      - store_artifacts:
+          path: cypress/results
+          destination: mochawesome-report
+
+workflows:
+  version: 2
+  run-cypress-tests:
+    jobs:
+      - cypress-tests


### PR DESCRIPTION
This pull request introduces a new CI/CD pipeline configuration to run Cypress tests in a CircleCI environment. The changes include setting up a Node.js-based executor, installing dependencies, running tests in Google Chrome, and generating test reports.

### CI/CD Pipeline Setup:
* **Added CircleCI configuration**: Introduced a new `.circleci/config.yml` file to define a pipeline for running Cypress tests. This includes a `node-executor` using the `cimg/node:22.1.0-browsers` Docker image.
* **Dependency management**: Configured steps to install Node.js dependencies using `npm ci` and cache them for faster subsequent builds.
* **Google Chrome installation**: Added commands to install Google Chrome in the CI environment to enable browser-based testing.
* **Cypress test execution**: Configured the pipeline to run Cypress tests using the `npm run test:cci` command, ensuring tests are executed in Chrome.
* **Test report generation**: Integrated `mochawesome` to merge test results, generate HTML reports, and store them as build artifacts.